### PR TITLE
Update handbook link

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ You can now cd into my-project
 $ cd my-project
 ```
 
-Choo-cli will create a directory structure that [we've found to be optimal](https://github.com/yoshuawuyts/choo-handbook/blob/master/designing-for-reusability.md) for slim
+Choo-cli will create a directory structure that [we've found to be optimal](https://github.com/yoshuawuyts/choo-handbook/blob/master/guides/designing-for-reusability.md) for slim
 applications and reusability.
 
 ```txt

--- a/generators/app/template/README.md
+++ b/generators/app/template/README.md
@@ -1,6 +1,6 @@
 # <%= projectName %> [![built with choo v3](https://img.shields.io/badge/built%20with%20choo-v3-ffc3e4.svg?style=flat-square)](https://github.com/yoshuawuyts/choo)
 
-Choo-cli created a directory structure that [we've found to be optimal](https://github.com/yoshuawuyts/choo-handbook/blob/master/designing-for-reusability.md) for slim
+Choo-cli created a directory structure that [we've found to be optimal](https://github.com/yoshuawuyts/choo-handbook/blob/master/guides/designing-for-reusability.md) for slim
 applications and reusability.
 
 ```txt

--- a/generators/app/template/assets/README.md
+++ b/generators/app/template/assets/README.md
@@ -2,4 +2,4 @@
 
 here's a nice place to put your images and fonts, if you have any.
 
-More information:  https://github.com/yoshuawuyts/choo-handbook/blob/master/designing-for-reusability.md
+More information:  https://github.com/yoshuawuyts/choo-handbook/blob/master/guides/designing-for-reusability.md

--- a/generators/app/template/elements/README.md
+++ b/generators/app/template/elements/README.md
@@ -2,7 +2,7 @@
 
 Standalone application-specific elements.
 
-More information:  https://github.com/yoshuawuyts/choo-handbook/blob/master/designing-for-reusability.md
+More information:  https://github.com/yoshuawuyts/choo-handbook/blob/master/guides/designing-for-reusability.md
 
 ### Generate
 

--- a/generators/app/template/lib/README.md
+++ b/generators/app/template/lib/README.md
@@ -2,4 +2,4 @@
 
 Generalized components, should be moved out of project later
 
-More information:  https://github.com/yoshuawuyts/choo-handbook/blob/master/designing-for-reusability.md
+More information:  https://github.com/yoshuawuyts/choo-handbook/blob/master/guides/designing-for-reusability.md

--- a/generators/app/template/models/README.md
+++ b/generators/app/template/models/README.md
@@ -2,7 +2,7 @@
 
 Choo Models go here.
 
-More information:  https://github.com/yoshuawuyts/choo-handbook/blob/master/designing-for-reusability.md
+More information:  https://github.com/yoshuawuyts/choo-handbook/blob/master/guides/designing-for-reusability.md
 
 ### Generate
 

--- a/generators/app/template/pages/README.md
+++ b/generators/app/template/pages/README.md
@@ -2,7 +2,7 @@
 
 Views that are directly mounted on the router
 
-More information:  https://github.com/yoshuawuyts/choo-handbook/blob/master/designing-for-reusability.md
+More information:  https://github.com/yoshuawuyts/choo-handbook/blob/master/guides/designing-for-reusability.md
 
 ### Generate
 

--- a/generators/app/template/scripts/README.md
+++ b/generators/app/template/scripts/README.md
@@ -2,4 +2,4 @@
 
 shell scripts, to be interfaced with through `npm scripts`
 
-More information:  https://github.com/yoshuawuyts/choo-handbook/blob/master/designing-for-reusability.md
+More information:  https://github.com/yoshuawuyts/choo-handbook/blob/master/guides/designing-for-reusability.md


### PR DESCRIPTION
The handbook link was pointing to an old URL and giving a 404
