### PR TITLE
Update budo command with specific port

### DIFF
--- a/generators/app/template/_package.json
+++ b/generators/app/template/_package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {
     "build:prod": "scripts/build-prod.sh",
-    "start": "budo ./client.js --live --pushstate --open -- -g es2040",
+    "start": "budo ./client.js -p 8080 --live --pushstate --open -- -g es2040",
     "lint": "standard --verbose | snazzy",
     "test": "npm run lint"
   },


### PR DESCRIPTION
In the documentation `localhost:8080` is the referenced port, but Budo's default port is `localhost:9966`.

This could be done the other way round if you'd prefer `localhost:8080` -> `localhost:9966`

Sorry for all the PR's!
