### PR TITLE
adding a check for installation of yarn

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -7,6 +7,7 @@ const resolvePath = require('path').resolve
 const once = require('ramda').once
 const walkBack = require('walk-back')
 const chalk = require('chalk')
+const hasYarn = require('has-yarn')
 const delim = (require('os').platform() === 'win32') ? '\\' : '/'
 const message = msg => console.log(msg)
 const cwd = process.cwd()
@@ -27,7 +28,11 @@ const findRootPath = once(() => {
 
 const destinationPath = (dir) => resolvePath(findRootPath(), dir || '')
 const npmInstall = process.env.NODE_ENV === 'test' ? () => { } : () => process.nextTick(() => {
-  exec('npm', ['install', '-s'], { cwd: destinationPath() })
+  if (hasYarn(destinationPath())) {
+    exec('yarn', ['install'], { cwd: destinationPath() })
+  } else {
+    exec('npm', ['install', '-s'], { cwd: destinationPath() })
+  }
 })
 
 const generate = (templatePath, category, props) => {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "cli-spinners": "^1.0.0",
     "cross-spawn": "^5.0.1",
     "espree": "^3.3.2",
+    "has-yarn": "^1.0.0",
     "inquirer": "^2.0.0",
     "left-pad": "^1.1.1",
     "lodash": "^4.14.1",


### PR DESCRIPTION
the check is pretty simple, it makes sure that if a yarn.lock file is in the cwd that's being installed to, yarn is being used for installation.

I'm not 100% sure what `npm install -s` is supposed to do differently than `npm install`, and I couldn't find an alternative for yarn, so I kept it at this.

Let me know if I can do anything better or another way

Have a nice day!

I should probably add a unit test (although that'd be testing `has-yarn`, which does have 100% coverage)