### PR TITLE
Updating to generate files with the same extension of templates

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,13 +3,14 @@ const xfs = require('mem-fs-editor').create(store)
 const { kebabCase, camelCase } = require('lodash')
 const { parse } = require('espree')
 const exec = require('./exec')
-const resolvePath = require('path').resolve
+const path = require('path')
 const once = require('ramda').once
 const walkBack = require('walk-back')
 const chalk = require('chalk')
 const delim = (require('os').platform() === 'win32') ? '\\' : '/'
 const message = msg => console.log(msg)
 const cwd = process.cwd()
+const resolvePath = path.resolve
 
 const newProjectPath = (projectName) => (dir) => resolvePath(cwd, projectName, dir || '')
 const findConfig = once(() => walkBack(process.cwd(), 'choo.yaml'))
@@ -31,7 +32,8 @@ const npmInstall = process.env.NODE_ENV === 'test' ? () => { } : () => process.n
 })
 
 const generate = (templatePath, category, props) => {
-  const fileName = `${kebabCase(props.name)}.js`
+  const extName = path.extname(templatePath)
+  const fileName = `${kebabCase(props.name)}${extName}`
   const targetPath = resolvePath(findRootPath(), props.path || category)
   const dest = destinationPath(`${targetPath}/${fileName}`)
   xfs.copyTpl(`${templatePath}`, dest, props)


### PR DESCRIPTION
Currently, the generator only supports `*.js`, but this PR enables it to accept more extensions like `*.ts`. Please check out this PR after https://github.com/trainyard/choo-cli/pull/109 which fixes all failing tests.