### PR TITLE
Remove model test and store test instead

### DIFF
--- a/tests/generators/app.js
+++ b/tests/generators/app.js
@@ -5,7 +5,7 @@ const clinton = require('clinton')
 const exec = require('../../lib/exec')
 
 test('App Generator', t => {
-  t.plan(13)
+  t.plan(12)
   exec('choo-new.js', ['temp'], {
     cwd: testUtils.cwd
   }, () => {
@@ -14,8 +14,7 @@ test('App Generator', t => {
         'assets/README.md',
         'elements/README.md',
         'lib/README.md',
-        'models/app.js',
-        'models/README.md',
+        'stores/home.js',
         'pages/home.js',
         'pages/README.md',
         '.editorconfig',

--- a/tests/generators/store.js
+++ b/tests/generators/store.js
@@ -3,13 +3,13 @@ const test = require('tape')
 const testUtils = require('../../lib/test-utils')
 const exec = require('../../lib/exec')
 
-test('Model Generator', t => {
+test('Store generator', t => {
   t.plan(1)
-  exec('choo-generate.js', ['model', 'testModel'], {
+  exec('choo-generate.js', ['store', 'testStore'], {
     cwd: testUtils.tempDir
   }, () => {
     testUtils.filesExist([
-      'models/test-model.js'
+      'stores/test-store.js'
     ]).forEach(file => {
       t.assert(file.exists, `${file.name} must be generated.`)
     })


### PR DESCRIPTION
- [trainyard/template-basic](https://github.com/trainyard/template-basic) is now compatible with choo 6 which does not support `model` as it was.
- This PR removes model test, because it is deprecated. Instead, this PR adds store generator test which is available in choo 6